### PR TITLE
Use font-lock-flush (and no font-lock-ensure) if available

### DIFF
--- a/unicode-troll-stopper.el
+++ b/unicode-troll-stopper.el
@@ -59,7 +59,9 @@
   (if unicode-troll-stopper-mode
       (font-lock-add-keywords nil unicode-troll-stopper--keywords)
     (font-lock-remove-keywords nil unicode-troll-stopper--keywords))
-  (font-lock-fontify-region (point-min) (point-max)))
+  (if (fboundp 'font-lock-flush)
+      (font-lock-flush)
+    (font-lock-fontify-region (point-min) (point-max))))
 
 (provide 'unicode-troll-stopper)
 ;;; unicode-troll-stopper.el ends here


### PR DESCRIPTION
Having `(add-hook 'nxml-mode-hook #'unicode-troll-stopper-mode)` 
and then opening
https://svn.code.sf.net/p/apertium/svn/trunk/apertium-sme-nob/apertium-sme-nob.sme-nob.dix
would lead to fontifying the whole 75728 line xml file. 

If we're on Emacs 25, we can just "forget" fontification information
instead, which will do the right thing. (There may be a similar
function in <25, I don't know.)

